### PR TITLE
lesson-09 / 9e.css

### DIFF
--- a/1-exercise-solutions/lesson-09/9e.css
+++ b/1-exercise-solutions/lesson-09/9e.css
@@ -22,6 +22,7 @@
   border: none;
   width: 300px;
   vertical-align: middle;
+  display: inline-block;
 }
 
 .tweet-button {


### PR DESCRIPTION
The class labeled 'text-box' missed a very important property called `display: inline-block;` due to which all of the elements were appearing on top of each other. The same problem was appearing when I was practicing the tweet box in lesson#07 exercise 7g. but then I didn't know the CSS display property as it's the lesson after lesson no. 07 where mate Simon briefly explains the types of HTML elements and display properties.